### PR TITLE
Panel requests file on startup

### DIFF
--- a/src/webView.ts
+++ b/src/webView.ts
@@ -5,7 +5,7 @@ import { SvelteWebviewInitializer } from './svelteWebviewInitializer'
 export class WebView implements vscode.Disposable {
   private panel: vscode.WebviewPanel
   private svelteWebviewInitializer: SvelteWebviewInitializer
-  private fileToEdit: string | null = ""
+  private fileToEdit: string = ""
 
   constructor(
     protected context: vscode.ExtensionContext,

--- a/src/webView.ts
+++ b/src/webView.ts
@@ -1,9 +1,11 @@
 import * as vscode from 'vscode'
+import * as fs from 'fs'
 import { SvelteWebviewInitializer } from './svelteWebviewInitializer'
 
 export class WebView implements vscode.Disposable {
   private panel: vscode.WebviewPanel
   private svelteWebviewInitializer: SvelteWebviewInitializer
+  private fileToEdit: string | null = ""
 
   constructor(
     protected context: vscode.ExtensionContext,
@@ -28,6 +30,20 @@ export class WebView implements vscode.Disposable {
   }
 
   private createPanel(title: string): vscode.WebviewPanel {
+    vscode.window
+      .showOpenDialog({
+      canSelectMany: false,
+      openLabel: 'Select',
+      canSelectFiles: true,
+      canSelectFolders: false,
+    })
+    .then((fileUri) => {
+      if (fileUri && fileUri[0]) {
+        this.fileToEdit = fileUri[0].fsPath
+      }
+      vscode.window.showInformationMessage("Selected file: " + this.fileToEdit)
+    })
+
     const column =
       vscode.window.activeTextEditor &&
       vscode.window.activeTextEditor.viewColumn


### PR DESCRIPTION
The panel now requests for selecting a file from the filesystem upon startup. The `vscode.window` function for selecting a file is asynchronous. I implemented saving the `fsPath` as a private member of the panel.

I left the return of the `createWebviewPanel` outside of the `showOpenDialog` thenable because I figured that we could let the default, empty panel appear and use vscode messages to sent to Omega Edit and populate the data.