### PR TITLE
Content control buttons post message to extension.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/glob": "^8.0.0",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^18.11.17",
+        "@types/node": "^18.11.18",
         "@types/vscode": "^1.63.0",
         "@typescript-eslint/eslint-plugin": "^5.47.1",
         "@typescript-eslint/parser": "^5.48.0",
@@ -253,9 +253,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
       "dev": true
     },
     "node_modules/@types/semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/node": "^18.11.17",
         "@types/vscode": "^1.63.0",
         "@typescript-eslint/eslint-plugin": "^5.47.1",
-        "@typescript-eslint/parser": "^5.1.0",
+        "@typescript-eslint/parser": "^5.48.0",
         "@vscode/test-electron": "^2.2.1",
         "concurrently": "^7.0.0",
         "eslint": "^8.1.0",
@@ -351,14 +351,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.47.0.tgz",
-      "integrity": "sha512-udPU4ckK+R1JWCGdQC4Qa27NtBg7w020ffHqGyAK8pAgOVuNw7YaKXGChk+udh+iiGIJf6/E/0xhVXyPAbsczw==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.0.tgz",
+      "integrity": "sha512-1mxNA8qfgxX8kBvRDIHEzrRGrKHQfQlbW6iHyfHYS0Q4X1af+S6mkLNtgCOsGVl8+/LUPrqdHMssAemkrQ01qg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.47.0",
-        "@typescript-eslint/types": "5.47.0",
-        "@typescript-eslint/typescript-estree": "5.47.0",
+        "@typescript-eslint/scope-manager": "5.48.0",
+        "@typescript-eslint/types": "5.48.0",
+        "@typescript-eslint/typescript-estree": "5.48.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -378,13 +378,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.47.0.tgz",
-      "integrity": "sha512-dvJab4bFf7JVvjPuh3sfBUWsiD73aiftKBpWSfi3sUkysDQ4W8x+ZcFpNp7Kgv0weldhpmMOZBjx1wKN8uWvAw==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.0.tgz",
+      "integrity": "sha512-0AA4LviDtVtZqlyUQnZMVHydDATpD9SAX/RC5qh6cBd3xmyWvmXYF+WT1oOmxkeMnWDlUVTwdODeucUnjz3gow==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.47.0",
-        "@typescript-eslint/visitor-keys": "5.47.0"
+        "@typescript-eslint/types": "5.48.0",
+        "@typescript-eslint/visitor-keys": "5.48.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.47.0.tgz",
-      "integrity": "sha512-eslFG0Qy8wpGzDdYKu58CEr3WLkjwC5Usa6XbuV89ce/yN5RITLe1O8e+WFEuxnfftHiJImkkOBADj58ahRxSg==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.0.tgz",
+      "integrity": "sha512-UTe67B0Ypius0fnEE518NB2N8gGutIlTojeTg4nt0GQvikReVkurqxd2LvYa9q9M5MQ6rtpNyWTBxdscw40Xhw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -492,13 +492,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.47.0.tgz",
-      "integrity": "sha512-LxfKCG4bsRGq60Sqqu+34QT5qT2TEAHvSCCJ321uBWywgE2dS0LKcu5u+3sMGo+Vy9UmLOhdTw5JHzePV/1y4Q==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.0.tgz",
+      "integrity": "sha512-7pjd94vvIjI1zTz6aq/5wwE/YrfIyEPLtGJmRfyNR9NYIW+rOvzzUv3Cmq2hRKpvt6e9vpvPUQ7puzX7VSmsEw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.47.0",
-        "@typescript-eslint/visitor-keys": "5.47.0",
+        "@typescript-eslint/types": "5.48.0",
+        "@typescript-eslint/visitor-keys": "5.48.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -619,12 +619,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.47.0.tgz",
-      "integrity": "sha512-ByPi5iMa6QqDXe/GmT/hR6MZtVPi0SqMQPDx15FczCBXJo/7M8T88xReOALAfpBLm+zxpPfmhuEvPb577JRAEg==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.0.tgz",
+      "integrity": "sha512-5motVPz5EgxQ0bHjut3chzBkJ3Z3sheYVcSwS5BpHZpLqSptSmELNtGixmgj65+rIfhvtQTz5i9OP2vtzdDH7Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.47.0",
+        "@typescript-eslint/types": "5.48.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.11.17",
         "@types/vscode": "^1.63.0",
-        "@typescript-eslint/eslint-plugin": "^5.1.0",
+        "@typescript-eslint/eslint-plugin": "^5.47.1",
         "@typescript-eslint/parser": "^5.1.0",
         "@vscode/test-electron": "^2.2.1",
         "concurrently": "^7.0.0",
@@ -271,14 +271,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.47.0.tgz",
-      "integrity": "sha512-AHZtlXAMGkDmyLuLZsRpH3p4G/1iARIwc/T0vIem2YB+xW6pZaXYXzCBnZSF/5fdM97R9QqZWZ+h3iW10XgevQ==",
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.47.1.tgz",
+      "integrity": "sha512-r4RZ2Jl9kcQN7K/dcOT+J7NAimbiis4sSM9spvWimsBvDegMhKLA5vri2jG19PmIPbDjPeWzfUPQ2hjEzA4Nmg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.47.0",
-        "@typescript-eslint/type-utils": "5.47.0",
-        "@typescript-eslint/utils": "5.47.0",
+        "@typescript-eslint/scope-manager": "5.47.1",
+        "@typescript-eslint/type-utils": "5.47.1",
+        "@typescript-eslint/utils": "5.47.1",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -301,6 +301,53 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.47.1.tgz",
+      "integrity": "sha512-9hsFDsgUwrdOoW1D97Ewog7DYSHaq4WKuNs0LHF9RiCmqB0Z+XRR4Pf7u7u9z/8CciHuJ6yxNws1XznI3ddjEw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.47.1",
+        "@typescript-eslint/visitor-keys": "5.47.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.47.1.tgz",
+      "integrity": "sha512-CmALY9YWXEpwuu6377ybJBZdtSAnzXLSQcxLSqSQSbC7VfpMu/HLVdrnVJj7ycI138EHqocW02LPJErE35cE9A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.47.1.tgz",
+      "integrity": "sha512-rF3pmut2JCCjh6BLRhNKdYjULMb1brvoaiWDlHfLNVgmnZ0sBVJrs3SyaKE1XoDDnJuAx/hDQryHYmPUuNq0ig==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.47.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -348,13 +395,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.47.0.tgz",
-      "integrity": "sha512-1J+DFFrYoDUXQE1b7QjrNGARZE6uVhBqIvdaXTe5IN+NmEyD68qXR1qX1g2u4voA+nCaelQyG8w30SAOihhEYg==",
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.47.1.tgz",
+      "integrity": "sha512-/UKOeo8ee80A7/GJA427oIrBi/Gd4osk/3auBUg4Rn9EahFpevVV1mUK8hjyQD5lHPqX397x6CwOk5WGh1E/1w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.47.0",
-        "@typescript-eslint/utils": "5.47.0",
+        "@typescript-eslint/typescript-estree": "5.47.1",
+        "@typescript-eslint/utils": "5.47.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -372,6 +419,63 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.47.1.tgz",
+      "integrity": "sha512-CmALY9YWXEpwuu6377ybJBZdtSAnzXLSQcxLSqSQSbC7VfpMu/HLVdrnVJj7ycI138EHqocW02LPJErE35cE9A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.47.1.tgz",
+      "integrity": "sha512-4+ZhFSuISAvRi2xUszEj0xXbNTHceV9GbH9S8oAD2a/F9SW57aJNQVOCxG8GPfSWH/X4eOPdMEU2jYVuWKEpWA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.47.1",
+        "@typescript-eslint/visitor-keys": "5.47.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.47.1.tgz",
+      "integrity": "sha512-rF3pmut2JCCjh6BLRhNKdYjULMb1brvoaiWDlHfLNVgmnZ0sBVJrs3SyaKE1XoDDnJuAx/hDQryHYmPUuNq0ig==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.47.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -415,16 +519,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.47.0.tgz",
-      "integrity": "sha512-U9xcc0N7xINrCdGVPwABjbAKqx4GK67xuMV87toI+HUqgXj26m6RBp9UshEXcTrgCkdGYFzgKLt8kxu49RilDw==",
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.47.1.tgz",
+      "integrity": "sha512-l90SdwqfmkuIVaREZ2ykEfCezepCLxzWMo5gVfcJsJCaT4jHT+QjgSkYhs5BMQmWqE9k3AtIfk4g211z/sTMVw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.47.0",
-        "@typescript-eslint/types": "5.47.0",
-        "@typescript-eslint/typescript-estree": "5.47.0",
+        "@typescript-eslint/scope-manager": "5.47.1",
+        "@typescript-eslint/types": "5.47.1",
+        "@typescript-eslint/typescript-estree": "5.47.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -438,6 +542,80 @@
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.47.1.tgz",
+      "integrity": "sha512-9hsFDsgUwrdOoW1D97Ewog7DYSHaq4WKuNs0LHF9RiCmqB0Z+XRR4Pf7u7u9z/8CciHuJ6yxNws1XznI3ddjEw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.47.1",
+        "@typescript-eslint/visitor-keys": "5.47.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.47.1.tgz",
+      "integrity": "sha512-CmALY9YWXEpwuu6377ybJBZdtSAnzXLSQcxLSqSQSbC7VfpMu/HLVdrnVJj7ycI138EHqocW02LPJErE35cE9A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.47.1.tgz",
+      "integrity": "sha512-4+ZhFSuISAvRi2xUszEj0xXbNTHceV9GbH9S8oAD2a/F9SW57aJNQVOCxG8GPfSWH/X4eOPdMEU2jYVuWKEpWA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.47.1",
+        "@typescript-eslint/visitor-keys": "5.47.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.47.1.tgz",
+      "integrity": "sha512-rF3pmut2JCCjh6BLRhNKdYjULMb1brvoaiWDlHfLNVgmnZ0sBVJrs3SyaKE1XoDDnJuAx/hDQryHYmPUuNq0ig==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.47.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@typescript-eslint/parser": "^5.48.0",
         "@vscode/test-electron": "^2.2.1",
         "concurrently": "^7.0.0",
-        "eslint": "^8.1.0",
+        "eslint": "^8.31.0",
         "eslint-plugin-prettier": "^4.2.1",
         "glob": "^8.0.3",
         "mocha": "^10.2.0",
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.0.tgz",
-      "integrity": "sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+      "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -1524,12 +1524,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.30.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.30.0.tgz",
-      "integrity": "sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==",
+      "version": "8.31.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz",
+      "integrity": "sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.4.0",
+        "@eslint/eslintrc": "^1.4.1",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.11.17",
     "@types/vscode": "^1.63.0",
-    "@typescript-eslint/eslint-plugin": "^5.1.0",
+    "@typescript-eslint/eslint-plugin": "^5.47.1",
     "@typescript-eslint/parser": "^5.1.0",
     "@vscode/test-electron": "^2.2.1",
     "concurrently": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/glob": "^8.0.0",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.11.17",
+    "@types/node": "^18.11.18",
     "@types/vscode": "^1.63.0",
     "@typescript-eslint/eslint-plugin": "^5.47.1",
     "@typescript-eslint/parser": "^5.48.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@typescript-eslint/parser": "^5.48.0",
     "@vscode/test-electron": "^2.2.1",
     "concurrently": "^7.0.0",
-    "eslint": "^8.1.0",
+    "eslint": "^8.31.0",
     "eslint-plugin-prettier": "^4.2.1",
     "glob": "^8.0.3",
     "mocha": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/node": "^18.11.17",
     "@types/vscode": "^1.63.0",
     "@typescript-eslint/eslint-plugin": "^5.47.1",
-    "@typescript-eslint/parser": "^5.1.0",
+    "@typescript-eslint/parser": "^5.48.0",
     "@vscode/test-electron": "^2.2.1",
     "concurrently": "^7.0.0",
     "eslint": "^8.1.0",

--- a/src/webView.ts
+++ b/src/webView.ts
@@ -16,7 +16,7 @@ type EditorMessage = {
 export class WebView implements vscode.Disposable {
   private panel: vscode.WebviewPanel
   private svelteWebviewInitializer: SvelteWebviewInitializer
-  private fileToEdit: string | null = ""
+  private fileToEdit: string = ""
 
   constructor(
     protected context: vscode.ExtensionContext,

--- a/src/webView.ts
+++ b/src/webView.ts
@@ -1,6 +1,13 @@
 import * as vscode from 'vscode'
 import { SvelteWebviewInitializer } from './svelteWebviewInitializer'
 
+/** Data editor message data structure for communication between Webview and VSCode. */
+type EditorMessage = {
+  command: string,
+  data: string,
+  srcElement?: string
+}
+
 export class WebView implements vscode.Disposable {
   private panel: vscode.WebviewPanel
   private svelteWebviewInitializer: SvelteWebviewInitializer
@@ -11,6 +18,8 @@ export class WebView implements vscode.Disposable {
     title: string
   ) {
     this.panel = this.createPanel(title)
+    this.panel.webview.onDidReceiveMessage(this.messageReceiver)
+
     this.svelteWebviewInitializer = new SvelteWebviewInitializer(context)
     this.svelteWebviewInitializer.initialize(this.view, this.panel.webview)
   }
@@ -34,5 +43,14 @@ export class WebView implements vscode.Disposable {
         ? vscode.window.activeTextEditor?.viewColumn
         : vscode.ViewColumn.Active
     return vscode.window.createWebviewPanel(this.view, title, column)
+  }
+
+  private messageReceiver(message: EditorMessage) {
+    if( message.srcElement === "commit_btn" ) {
+      vscode.window.showInformationMessage(`Sending commit changes message to Omega Edit.\nData: ${message.data}`);
+    }
+    if( message.srcElement === "add_data_breakpoint_button" ) {
+      vscode.window.showInformationMessage(`Sending add breakpoint message to Omega Edit.\nData: ${message.data}`);
+    }
   }
 }

--- a/src/webView.ts
+++ b/src/webView.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+import * as fs from 'fs'
 import { SvelteWebviewInitializer } from './svelteWebviewInitializer'
 
 enum MessageCommand {
@@ -15,6 +16,7 @@ type EditorMessage = {
 export class WebView implements vscode.Disposable {
   private panel: vscode.WebviewPanel
   private svelteWebviewInitializer: SvelteWebviewInitializer
+  private fileToEdit: string | null = ""
 
   constructor(
     protected context: vscode.ExtensionContext,
@@ -41,6 +43,20 @@ export class WebView implements vscode.Disposable {
   }
 
   private createPanel(title: string): vscode.WebviewPanel {
+    vscode.window
+      .showOpenDialog({
+      canSelectMany: false,
+      openLabel: 'Select',
+      canSelectFiles: true,
+      canSelectFolders: false,
+    })
+    .then((fileUri) => {
+      if (fileUri && fileUri[0]) {
+        this.fileToEdit = fileUri[0].fsPath
+      }
+      vscode.window.showInformationMessage("Selected file: " + this.fileToEdit)
+    })
+
     const column =
       vscode.window.activeTextEditor &&
       vscode.window.activeTextEditor.viewColumn

--- a/src/webView.ts
+++ b/src/webView.ts
@@ -1,11 +1,15 @@
 import * as vscode from 'vscode'
 import { SvelteWebviewInitializer } from './svelteWebviewInitializer'
 
+enum MessageCommand {
+  commit,
+  addBreakpoint,
+}
 /** Data editor message data structure for communication between Webview and VSCode. */
 type EditorMessage = {
-  command: string,
+  command: MessageCommand,
   data: string,
-  srcElement?: string
+  srcElement?: HTMLElement
 }
 
 export class WebView implements vscode.Disposable {
@@ -46,11 +50,10 @@ export class WebView implements vscode.Disposable {
   }
 
   private messageReceiver(message: EditorMessage) {
-    if( message.srcElement === "commit_btn" ) {
-      vscode.window.showInformationMessage(`Sending commit changes message to Omega Edit.\nData: ${message.data}`);
-    }
-    if( message.srcElement === "add_data_breakpoint_button" ) {
-      vscode.window.showInformationMessage(`Sending add breakpoint message to Omega Edit.\nData: ${message.data}`);
+    vscode.window.showInformationMessage(`Received <${message.command}> signal from UI.`);
+    
+    switch( message.command ) {
+      // TODO: Specific cmd functionality to Omega Edit.
     }
   }
 }

--- a/svelte/package-lock.json
+++ b/svelte/package-lock.json
@@ -12,7 +12,7 @@
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-typescript": "^10.0.1",
         "@tsconfig/svelte": "^3.0.0",
-        "rollup": "^3.8.1",
+        "rollup": "^3.9.1",
         "rollup-plugin-multi-input": "^1.3.1",
         "rollup-plugin-polyfill-node": "^0.11.0",
         "rollup-plugin-scss": "^4.0.0",
@@ -978,9 +978,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.8.1.tgz",
-      "integrity": "sha512-4yh9eMW7byOroYcN8DlF9P/2jCpu6txVIHjEqquQVSx7DI0RgyCCN3tjrcy4ra6yVtV336aLBB3v2AarYAxePQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.9.1.tgz",
+      "integrity": "sha512-GswCYHXftN8ZKGVgQhTFUJB/NBXxrRGgO2NCy6E8s1rwEJ4Q9/VttNqcYfEvx4dTo4j58YqdC3OVztPzlKSX8w==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"

--- a/svelte/package-lock.json
+++ b/svelte/package-lock.json
@@ -12,7 +12,7 @@
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-typescript": "^10.0.1",
         "@tsconfig/svelte": "^3.0.0",
-        "rollup": "^3.8.0",
+        "rollup": "^3.8.1",
         "rollup-plugin-multi-input": "^1.3.1",
         "rollup-plugin-polyfill-node": "^0.11.0",
         "rollup-plugin-scss": "^4.0.0",
@@ -978,9 +978,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.8.0.tgz",
-      "integrity": "sha512-+UR6PnUslneJNiJfLSzy4XH6R50ZGF0MS7UCv20ftXrktF/TkvZDwiBtXX65esblLR5p8w6LmXgPwt2f2B8SoQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.8.1.tgz",
+      "integrity": "sha512-4yh9eMW7byOroYcN8DlF9P/2jCpu6txVIHjEqquQVSx7DI0RgyCCN3tjrcy4ra6yVtV336aLBB3v2AarYAxePQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -13,7 +13,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^10.0.1",
     "@tsconfig/svelte": "^3.0.0",
-    "rollup": "^3.8.0",
+    "rollup": "^3.8.1",
     "rollup-plugin-multi-input": "^1.3.1",
     "rollup-plugin-polyfill-node": "^0.11.0",
     "rollup-plugin-scss": "^4.0.0",

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -13,7 +13,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^10.0.1",
     "@tsconfig/svelte": "^3.0.0",
-    "rollup": "^3.8.1",
+    "rollup": "^3.9.1",
     "rollup-plugin-multi-input": "^1.3.1",
     "rollup-plugin-polyfill-node": "^0.11.0",
     "rollup-plugin-scss": "^4.0.0",

--- a/svelte/src/components/dataEditor.svelte
+++ b/svelte/src/components/dataEditor.svelte
@@ -267,10 +267,10 @@
       refreshEditor()
     })
     editor_state.editor_elements.commit_button.addEventListener('click', () => {
-      vscode.postMessage({command: "commit", data: "testdata", srcElement: "commit_btn"});
+      vscode.postMessage({command: "commit", data: "testdata"});
     })
     editor_state.editor_elements.add_data_breakpoint_button.addEventListener('click', () => {
-      vscode.postMessage({command: "set_break", data: "testdata", srcElement: "add_data_breakpoint_button"});
+      vscode.postMessage({command: "set_break", data: "testdata"});
     })
     
     const advanced_mode = document.getElementById(

--- a/svelte/src/components/dataEditor.svelte
+++ b/svelte/src/components/dataEditor.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  const vscode = acquireVsCodeApi();
+  
   interface EditorControls {
     bytes_per_line: number
     address_numbering: number
@@ -264,6 +266,13 @@
       updateDataView()
       refreshEditor()
     })
+    editor_state.editor_elements.commit_button.addEventListener('click', () => {
+      vscode.postMessage({command: "commit", data: "testdata", srcElement: "commit_btn"});
+    })
+    editor_state.editor_elements.add_data_breakpoint_button.addEventListener('click', () => {
+      vscode.postMessage({command: "set_break", data: "testdata", srcElement: "add_data_breakpoint_button"});
+    })
+    
     const advanced_mode = document.getElementById(
       'advanced_mode'
     ) as HTMLInputElement

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
 		"module": "commonjs",
 		"target": "ES2020",
 		"lib": [
-			"ES2020"
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
 		],
 		"sourceMap": true,
 		"rootDir": "src",


### PR DESCRIPTION
The `commit_btn` and `add_data_breakpoint_btn` now post messages to the webview->extension direction messages.

**Note**: In the `dataEditor.svelte` file, the required `acquireVsCodeApi()` does not resolve but still successfully invokes the function allowing messages to post. Not sure why it's not visible from within the `svelte/src/components/` workspace.